### PR TITLE
課題31CloudWatchAlarmの追加、WAFWebACLの追加、WAFWebACLをCloudWatchと連携

### DIFF
--- a/課題31 aws-study-cwalarm-wafacl-logs.yaml
+++ b/課題31 aws-study-cwalarm-wafacl-logs.yaml
@@ -311,8 +311,8 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       Tags:
-      - Key: Name
-        Value: !Sub "${NamePrefix}-ec2cpu-alarm"
+        - Key: Name
+          Value: !Sub "${NamePrefix}-ec2cpu-alarm"
 
   # WAF WebACL
   WebACL:
@@ -341,8 +341,8 @@ Resources:
             CloudWatchMetricsEnabled: true
             MetricName: !Sub "${NamePrefix}-core-rules"
       Tags:
-      - Key: Name
-        Value: !Sub "${NamePrefix}-waf"
+        - Key: Name
+          Value: !Sub "${NamePrefix}-waf"
 
   # WAF WebACLをALBに関連付け
   WebACLAssociation:

--- a/課題31 aws-study-cwalarm-wafacl-logs.yaml
+++ b/課題31 aws-study-cwalarm-wafacl-logs.yaml
@@ -1,0 +1,370 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: cloudwatchalarm-wafwebacl-waflogs
+
+Parameters:
+  NamePrefix:
+    Type: String
+    Default: aws-study
+    Description: "リソース名の接頭辞（プレフィックス）"
+
+  MyIP:
+    Type: String
+    Default: 61.127.159.128/32
+    Description: "自分のPCからSSH接続できるIPアドレス"
+
+  DBPassword:
+    Type: String
+    NoEcho: true
+    MinLength: 8
+    MaxLength: 41
+    Description: "RDSのマスターパスワード（8〜41文字）"
+
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: "EC2インスタンスに使用するキーペア名"
+
+Resources:
+  # VPC作成
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-vpc"
+
+  # パブリックサブネット
+  PublicSubnetAZ1a:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.1.0/24
+      AvailabilityZone: ap-northeast-1a
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-subnet-public1a"
+
+  PublicSubnetAZ1c:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.3.0/24
+      AvailabilityZone: ap-northeast-1c
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-subnet-public1c"
+
+  # プライベートサブネット
+  PrivateSubnetAZ1a:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.2.0/24
+      AvailabilityZone: ap-northeast-1a
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-subnet-private1a"
+
+  PrivateSubnetAZ1c:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.4.0/24
+      AvailabilityZone: ap-northeast-1c
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-subnet-private1c"
+
+  # インターネットゲートウェイ
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-igw"
+
+  AttachIGW:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  # ルートテーブル（パブリック）
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rtb-public"
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachIGW
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  # ルートテーブル（プライベート）
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rtb-private"
+
+  # サブネットとルートテーブルの関連付け
+  PublicSubnetAZ1aAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetAZ1a
+
+  PublicSubnetAZ1cAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetAZ1c
+
+  PrivateSubnetAZ1aAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnetAZ1a
+
+  PrivateSubnetAZ1cAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnetAZ1c
+
+  # セキュリティグループ（ALB用）
+  SecurityGroupALB:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "ALB HTTP access"
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-alb-sg"
+
+  # セキュリティグループ（EC2用）
+  SecurityGroupEC2:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "EC2 SSH & HTTP from ALB"
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref MyIP
+        - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
+          SourceSecurityGroupId: !Ref SecurityGroupALB
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-ec2-sg"
+
+  # セキュリティグループ（RDS用）
+  SecurityGroupRDS:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "RDS MySQL from EC2"
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 3306
+          ToPort: 3306
+          SourceSecurityGroupId: !Ref SecurityGroupEC2
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rds-sg"
+
+  # EC2インスタンス
+  EC2:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Sub "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64}}"
+      InstanceType: t3.micro
+      KeyName: !Ref KeyName
+      SubnetId: !Ref PublicSubnetAZ1a
+      SecurityGroupIds:
+        - !Ref SecurityGroupEC2
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-ec2"
+
+  # RDSインスタンス
+  RDS:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: !Sub "${NamePrefix}-rds"
+      DBName: awsstudy
+      Engine: mysql
+      EngineVersion: "8.0.42"
+      DBInstanceClass: db.t4g.micro
+      AllocatedStorage: 20
+      StorageType: gp3
+      MasterUsername: root
+      MasterUserPassword: !Ref DBPassword
+      PubliclyAccessible: false
+      DBSubnetGroupName: !Ref DBSubnetGroup
+      BackupRetentionPeriod: 7
+      MultiAZ: false
+      AllowMajorVersionUpgrade: false
+      AutoMinorVersionUpgrade: true
+      VPCSecurityGroups:
+        - !Ref SecurityGroupRDS
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rds"
+
+  # サブネットグループ（RDS用）
+  DBSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: "RDS Private Subnet Group"
+      SubnetIds:
+        - !Ref PrivateSubnetAZ1a
+        - !Ref PrivateSubnetAZ1c
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-rds-subnet-group"
+
+  # ALB
+  ALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "${NamePrefix}-alb"
+      Subnets:
+        - !Ref PublicSubnetAZ1a
+        - !Ref PublicSubnetAZ1c
+      SecurityGroups:
+        - !Ref SecurityGroupALB
+      Scheme: internet-facing
+      Type: application
+      IpAddressType: ipv4
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-alb"
+
+  # ターゲットグループ（ALB用）
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "${NamePrefix}-tg"
+      VpcId: !Ref VPC
+      Protocol: HTTP
+      Port: 8080
+      TargetType: instance
+      Targets:
+      - Id: !Ref EC2
+      HealthCheckProtocol: HTTP
+      HealthCheckPort: "8080"
+      HealthCheckPath: "/"
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Matcher:
+        HttpCode: 200
+
+  # リスナー（ALB用）
+  Listener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  # CloudWatch Alarm
+  EC2CPUAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: "aws-study-ec2cpu-alarm"
+      AlarmDescription: "CPU Alarm 3%"
+      Namespace: "AWS/EC2"
+      MetricName: "CPUUtilization"
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref EC2
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Tags:
+      - Key: Name
+        Value: !Sub "${NamePrefix}-ec2cpu-alarm"
+
+  # WAF WebACL
+  WebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: !Sub "${NamePrefix}-waf"
+      Description: "ALB protection using Core rule set"
+      Scope: REGIONAL
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Sub "${NamePrefix}-waf"
+      Rules:
+        - Name: CoreRuleSet
+          Priority: 1
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Sub "${NamePrefix}-core-rules"
+      Tags:
+      - Key: Name
+        Value: !Sub "${NamePrefix}-waf"
+
+  # WAF WebACLをALBに関連付け
+  WebACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Ref ALB
+      WebACLArn: !GetAtt WebACL.Arn
+
+  # CloudWatch Logsグループ（WAF WebACL用）
+  WAFLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "aws-waf-logs-${NamePrefix}-waf"
+      RetentionInDays: 7
+      Tags:
+        - Key: Name
+          Value: !Sub "${NamePrefix}-waf-loggroup"
+
+  # WAF ログ設定
+  WAFLoggingConfiguration:
+    Type: AWS::WAFv2::LoggingConfiguration
+    Properties:
+      ResourceArn: !GetAtt WebACL.Arn
+      LogDestinationConfigs:
+        - !GetAtt WAFLogGroup.Arn


### PR DESCRIPTION
<img width="1919" height="907" alt="課題31 添付スクリーンショット 2025-08-31 155220" src="https://github.com/user-attachments/assets/cd893ef8-7cf7-4156-a80c-dc14c6211f43" />
<img width="1919" height="907" alt="課題31 添付スクリーンショット 2025-08-31 162029" src="https://github.com/user-attachments/assets/c6ef87e7-9dcb-4a13-8a2f-02a0142ca495" />
<img width="1919" height="907" alt="課題31 添付スクリーンショット 2025-08-31 162120" src="https://github.com/user-attachments/assets/a917f528-6602-4f6b-a713-063288dc9895" />
<img width="1919" height="911" alt="課題31 添付スクリーンショット 2025-08-31 162130" src="https://github.com/user-attachments/assets/135b84ea-eb63-4c69-b33a-742f2d89448c" />

## 実装内容
EC2CPUにCloudWatchAlarm設定の追加
ALBにWAFWebACLの追加
WAFWebACLのログをCloudWatchロググループで見るための連携

## 動作確認
アラーム設定ができているかをstressコマンドを使用して確認
ALBにWAFWebACLが設定されているかをコンソールで確認
WAFWebACLがログを出力してCloudWatchロググループで見れるかをコンソールで確認

## 工夫した点・学んだこと
WAFWebACLをCloudWatchと連携させるコードがうまくスタック作成ができず大変でした。
原因はCloudWatchロググループの名前が「aws-waf-logs-◯◯◯◯」という公式ドキュメントで定められたルールに気付けなかったことでした。
ARNが有効ではないというエラーだったのでARNの書き換えやロールのアタッチを繰り返し行っていました。
エラー文を再度確認したことでロググループ名が原因だと気づくことが出来ました。
検証を行いARNの書き換えとロールのアタッチは必要ないことがわかりました。
時間はかかりましたがエラー時の調べ方についての勉強になりました。